### PR TITLE
Many changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.TechFortress</groupId>
             <artifactId>GriefPrevention</artifactId>
-            <version>16.15.0</version>
+            <version>HEAD</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.17.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/SetClaimFlagCmd.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/SetClaimFlagCmd.java
@@ -67,7 +67,7 @@ class SetClaimFlagCmd extends BaseCmd {
                 return true;
             }
 
-            if (claim.allowEdit(player) != null) {
+            if (claim.checkPermission(player, ClaimPermission.Build, null) != null) {
                 Util.sendMessage(player, TextMode.Err, Messages.NotYourClaim);
                 return true;
             }

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/SetClaimFlagCmd.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/SetClaimFlagCmd.java
@@ -67,7 +67,7 @@ class SetClaimFlagCmd extends BaseCmd {
                 return true;
             }
 
-            if (claim.checkPermission(player, ClaimPermission.Build, null) != null) {
+            if (claim.checkPermission(player, ClaimPermission.Edit, null) != null) {
                 Util.sendMessage(player, TextMode.Err, Messages.NotYourClaim);
                 return true;
             }

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/SetClaimFlagCmd.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/SetClaimFlagCmd.java
@@ -28,7 +28,6 @@ class SetClaimFlagCmd extends BaseCmd {
     private final Collection<String> flagDefinitionNames;
 
 
-
     SetClaimFlagCmd(GPFlags plugin) {
         super(plugin);
         command = "SetClaimFlag";

--- a/src/main/java/me/ryanhamshire/GPFlags/commands/UnsetClaimFlagCmd.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/commands/UnsetClaimFlagCmd.java
@@ -8,6 +8,7 @@ import me.ryanhamshire.GPFlags.flags.FlagDef_ChangeBiome;
 import me.ryanhamshire.GPFlags.flags.FlagDefinition;
 import me.ryanhamshire.GPFlags.util.Util;
 import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import me.ryanhamshire.GriefPrevention.PlayerData;
 import org.bukkit.ChatColor;
@@ -58,7 +59,7 @@ public class UnsetClaimFlagCmd extends BaseCmd {
             return true;
         }
 
-        if (claim.allowEdit(player) != null) {
+        if (claim.checkPermission(player, ClaimPermission.Edit, null) != null) {
             Util.sendMessage(player, TextMode.Err, Messages.NotYourClaim);
             return true;
         }

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoMobDamage.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoMobDamage.java
@@ -47,6 +47,10 @@ public class FlagDef_NoMobDamage extends FlagDefinition {
         if (entity instanceof Animals || entity instanceof WaterMob || entity.getType() == EntityType.VILLAGER || entity.getCustomName() != null) {
             Flag flag = this.GetFlagInstanceAtLocation(entity.getLocation(), null);
             if (flag == null) return;
+
+            // fix for GP discussion https://github.com/TechFortress/GriefPrevention/issues/1481
+            if (event.getDamage() == 0 && event.getCause() == DamageCause.CUSTOM) return;
+
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
This is the same as #14. I'm just recreating the pull request because I accidentally deleted the old one. 

My changes:
- Stop using the depreciated method claim.allowEdit() because that now calls null.get() and produced NPE. Not sure if they made a mistake or if I just don’t understand the purpose of the .get() there. This should fix compatibility when GP 16.17.2 comes out because Gpflags doesn’t work with the current GP dev builds. However, since the method I switched to is new, I think this version will not work with GP 16.17.1 release, and one of the 16.17.2 snapshots will be required instead.
- In order to do the above change, I also needed to change the GP dependency in the pom to use HEAD. Not sure if this is acceptable programming, but it seemed to work where trying 16.17.2-SNAPSHOT wouldn’t.
- Update spigot dependency to 1.17.1.
- It’ll also make a temporary fix for NoMobDamage also preventing nametag usage. See GP discussion https://github.com/TechFortress/GriefPrevention/issues/1481.
- And finally, this will fix an NPE regarding the novehicle claimflag when it is used in /setdefaultclaimflag and boats are used outside of a claim.
